### PR TITLE
Changed things as mentioned in issue 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ y = model(x, x, x)
 print(y) # (1, 512, 64)
 ```
 
-An easy way to get the `E` and `F` matrices can be done by calling the `get_EF` function. As an example, for an `n` of `1000` and a `k` of `100`:
+An easy way to get the `E` and `F` matrices can be done by calling the `get_linear` function. As an example, for an `n` of `1000` and a `k` of `100`:
 
 ```python
-from linfromer_pytorch import get_EF
+from linfromer_pytorch import get_linear
 import torch
 
-E = get_EF(1000, 100)
+E = get_linear(1000, 100)
 ```
 
 ## Checkpoint levels


### PR DESCRIPTION
Changed some things in the code as mentioned here: https://github.com/tatp22/linformer-pytorch/issues/6

In particular, the following changes should be of note:

- Every `nn.Linear` instantiation is now replaced by the `get_linear` function, which returns an `nn.Linear` with xavier init. This also affects how the `E` and `F` matrices were initialized.

- There are no more `w_q`, `w_k`, and `w_v` matrices in the `LinearAttentionHead` module. Instead, in the `MHAttention` module, `to_{q,k,v}` is now a `ModuleList`, and there are `nhead` `nn.Linear` layers in each of them, each corresponding to the original weight matrix in the original paper.

- Fixed a bug where there were still `**kwargs` in the checkpoint function `"C2"`.