### PR TITLE
Use -inf as mask value for the causal mask

### DIFF
--- a/linformer_pytorch/linformer_pytorch.py
+++ b/linformer_pytorch/linformer_pytorch.py
@@ -163,7 +163,7 @@ class LinearAttentionHead(nn.Module):
         P_bar = Q/torch.sqrt(torch.tensor(self.dim).type(Q.type()))
         if self.causal_mask is not None:
             self.causal_mask = self.causal_mask.to(Q.device)
-            P_bar = P_bar.masked_fill_(~self.causal_mask, -1e10)
+            P_bar = P_bar.masked_fill_(~self.causal_mask, float('-inf'))
         P_bar = P_bar.softmax(dim=-1)
 
         # Only save this when visualizing


### PR DESCRIPTION
The value that is used for masking is currently set to -1e10. In FP16 respectively mixed precision training this leads to numerical issues. This can be fixed by using `float('-inf')` instead as infinity has an own special representation in IEEE 754.